### PR TITLE
Pass on 'connection' argment to Django email class

### DIFF
--- a/email_template/email.py
+++ b/email_template/email.py
@@ -74,6 +74,7 @@ def send_django_wrapper(**kwargs):
         to=kwargs["recipient_list"],
         headers=kwargs.get("headers", {}),
         cc=kwargs.get("cc", []),
+        connection=kwargs.get("connection", None),
     )
 
     if text and html:


### PR DESCRIPTION
This allows reusing the connection when sending many emails.
