### PR TITLE
Feature/django18 templates

### DIFF
--- a/email_template/email.py
+++ b/email_template/email.py
@@ -48,10 +48,11 @@ def render_django_fields(template, context):
     message["subject"] = render_node(template, "subject", context)
 
     recipients = render_node(template, "recipients", context)
-    recipient_list = []
-    for recipient in recipients.split(","):
-        recipient_list.append(recipient.strip())
-    message["recipient_list"] = recipient_list
+    message["recipient_list"] = [
+        email
+        for email in (item.strip() for item in recipients.split(','))
+        if email
+    ]
 
     return message
 

--- a/email_template/util.py
+++ b/email_template/util.py
@@ -3,7 +3,7 @@ from django.template.loader_tags import BlockNode
 
 
 def get_node(template, name):
-    if VERSION > (1.8):
+    if VERSION > (1, 8):
         # Pluggable template engines beget template wrapper classes
         template = template.template
     for node in template.nodelist.get_nodes_by_type(BlockNode):

--- a/email_template/util.py
+++ b/email_template/util.py
@@ -1,7 +1,11 @@
+from django import VERSION
 from django.template.loader_tags import BlockNode
 
 
 def get_node(template, name):
+    if VERSION > (1.8):
+        # Pluggable template engines beget template wrapper classes
+        template = template.template
     for node in template.nodelist.get_nodes_by_type(BlockNode):
         if node.name == name:
             return node

--- a/email_template/util.py
+++ b/email_template/util.py
@@ -14,5 +14,7 @@ def get_node(template, name):
 def render_node(template, name, context):
     node = get_node(template, name)
     if node:
+        if VERSION > (1, 8):
+            context.template = template
         return node.render(context).strip()
     return ""


### PR DESCRIPTION
With Pluggable Templates in Django 1.8 the Template class you receive is now a wrapper, and you have to access its `template` attribute to get what we need.
